### PR TITLE
turn off type: module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,46 +2,45 @@
   "name": "code-equality-assertions",
   "version": "0.9.0",
   "description": "",
-  "type": "module",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "default": "./dist/index.mjs"
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs"
+        "default": "./dist/index.js"
       }
     },
     "./qunit": {
       "import": {
         "types": "./dist/qunit.d.ts",
-        "default": "./dist/qunit.js"
+        "default": "./dist/qunit.mjs"
       },
       "require": {
         "types": "./dist/qunit.d.ts",
-        "default": "./dist/qunit.cjs"
+        "default": "./dist/qunit.js"
       }
     },
     "./jest": {
       "import": {
         "types": "./dist/jest.d.ts",
-        "default": "./dist/jest.js"
+        "default": "./dist/jest.mjs"
       },
       "require": {
         "types": "./dist/jest.d.ts",
-        "default": "./dist/jest.cjs"
+        "default": "./dist/jest.js"
       }
     },
     "./chai": {
       "import": {
         "types": "./dist/chai.d.ts",
-        "default": "./dist/chai.js"
+        "default": "./dist/chai.mjs"
       },
       "require": {
         "types": "./dist/chai.d.ts",
-        "default": "./dist/chai.cjs"
+        "default": "./dist/chai.js"
       }
     }
   },


### PR DESCRIPTION
This should have very little effect downstream because all it's doing is inverting the default import/require behaviour. 

I noticed this issue when I was building with TypeScript and `"moduleResolution": "Node16",` it doesn't seem to like the fact that you're building to commonjs and importing from something that is `type:module` even though the require was properly defined 🙈 

This is the error I was getting: 

```
The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("code-equality-assertions/qunit")' call instead.
  To convert this file to an ECMAScript module, change its file extension to '.mts', or add the field `"type": "module"` to '/Users/mansona/git/opensource/ember/embroider/test-packages/support/package.json'.

1 import { install } from 'code-equality-assertions/qunit';
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes it for some reason 🤷 